### PR TITLE
Added a flag that allows verbose macro/include statement output

### DIFF
--- a/source/vayne/compiler.d
+++ b/source/vayne/compiler.d
@@ -27,6 +27,7 @@ struct CompilerOptions {
 	auto constPrint = false;
 	auto lineNumbers = true;
 	auto compress = false;
+	auto verboseIncludes = false;
 
 	string[] search;
 	string ext = ".html";
@@ -81,7 +82,7 @@ CompiledCode compile(string fileName, CompilerOptions options) {
 
 		PreParserOptions preOptions;
 		preOptions.lineNumbers = options.lineNumbers;
-
+		preOptions.verboseIncludes = options.verboseIncludes;
 		mgr.set(src.id, preparse(mgr, src.id, preOptions));
 
 		if (options.preparsePrint)

--- a/source/vayne/source/preparser.d
+++ b/source/vayne/source/preparser.d
@@ -15,6 +15,7 @@ import vayne.source.token;
 
 struct PreParserOptions {
 	bool lineNumbers;
+	bool verboseIncludes;
 }
 
 
@@ -134,6 +135,9 @@ private:
 
 		if (needsLineNumbers(result))
 			result ~= sourceInfo(context.loc);
+
+		if (needsIncludeNames())
+			result =  format("<!-- begin include %s -->%s<!-- end include %s -->", content, result, content);
 		return result;
 	}
 
@@ -277,6 +281,9 @@ private:
 					auto result = parse(source, SourceLoc(source.id, pdef.loc.line, pdef.loc.column));
 					if (needsLineNumbers(result))
 						result ~= sourceInfo(context.loc);
+
+					if (needsIncludeNames)
+						result = format("<!-- begin macro #%s -->%s<!-- end macro #%s -->", name, result, name);
 					return result;
 				}
 			}
@@ -353,6 +360,10 @@ private:
 
 	auto needsLineNumbers(string content) const {
 		return options_.lineNumbers && !isAllWhite(content);
+	}
+
+	auto needsIncludeNames() {
+		return options_.verboseIncludes;
 	}
 
 	string sourceInfo(SourceLoc loc) {

--- a/source/vayne/source/preparser.d
+++ b/source/vayne/source/preparser.d
@@ -282,7 +282,7 @@ private:
 					if (needsLineNumbers(result))
 						result ~= sourceInfo(context.loc);
 
-					if (needsIncludeNames)
+					if (needsIncludeNames())
 						result = format("<!-- begin macro #%s -->%s<!-- end macro #%s -->", name, result, name);
 					return result;
 				}


### PR DESCRIPTION
Using this flag prints a comment before/after including a & or # section into the template.